### PR TITLE
shared scheme to allow usage in carthage

### DIFF
--- a/Framework/AutoCompletion/AutoCompletion.xcodeproj/xcshareddata/xcschemes/AutoCompletion.xcscheme
+++ b/Framework/AutoCompletion/AutoCompletion.xcodeproj/xcshareddata/xcschemes/AutoCompletion.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0730"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7AB6A1201C201A7900691478"
+               BuildableName = "AutoCompletion.framework"
+               BlueprintName = "AutoCompletion"
+               ReferencedContainer = "container:AutoCompletion.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7AB6A12A1C201A7900691478"
+               BuildableName = "AutoCompletionTests.xctest"
+               BlueprintName = "AutoCompletionTests"
+               ReferencedContainer = "container:AutoCompletion.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7AB6A1201C201A7900691478"
+            BuildableName = "AutoCompletion.framework"
+            BlueprintName = "AutoCompletion"
+            ReferencedContainer = "container:AutoCompletion.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7AB6A1201C201A7900691478"
+            BuildableName = "AutoCompletion.framework"
+            BlueprintName = "AutoCompletion"
+            ReferencedContainer = "container:AutoCompletion.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7AB6A1201C201A7900691478"
+            BuildableName = "AutoCompletion.framework"
+            BlueprintName = "AutoCompletion"
+            ReferencedContainer = "container:AutoCompletion.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Hey, thanks for putting together this really helpful framework! I'm sharing a small modification that enables using this framework as a Carthage package - all that's needed is to add a shared scheme. This file was auto generated by checking "shared" under "manage schemes".

You can then add it as a dependency in a Cartfile as follows:
github "3pillarlabs/ios-autocomplete" "master" (since it will pull the last release by default)
or 
github "3pillarlabs/ios-autocomplete" once this commit is included in a release
